### PR TITLE
Add Playwright scraper for ITF Masters 2026 Fred Perry Cup tie

### DIFF
--- a/scripts/itf-masters-scraper/README.md
+++ b/scripts/itf-masters-scraper/README.md
@@ -1,0 +1,28 @@
+# ITF Masters scraper — Denmark vs Germany (Fred Perry Cup 2026)
+
+Playwright script that extracts the result of the Denmark vs Germany tie
+(play-off for 5th/6th place, Fred Perry Cup / Men's 50) from the
+**ITF Masters World Team Championships 2026** (Rome, Italy, 5–10 July 2026)
+on `itfmasters.tournamentsoftware.com`.
+
+## Usage
+
+```bash
+npm install          # installs Playwright; downloads Chromium on first run
+node script.js
+```
+
+Optional environment variables:
+
+- `PW_EXECUTABLE_PATH` — use an existing Chromium binary instead of the
+  Playwright-managed download.
+- `HTTPS_PROXY` — route browser traffic through a proxy.
+
+## Why this was not executed in the sandbox
+
+The remote execution environment where this script was authored enforces an
+egress network policy that returns `403` on the proxy `CONNECT` for
+`itfmasters.tournamentsoftware.com` (and general web hosts), so the browser
+fails with `net::ERR_TUNNEL_CONNECTION_FAILED` before any page loads. The
+site additionally serves `403` to non-browser fetchers. Run the script from a
+machine with normal internet access to obtain the results.

--- a/scripts/itf-masters-scraper/package.json
+++ b/scripts/itf-masters-scraper/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "itf-masters-scraper",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright scraper for the Denmark vs Germany tie (Fred Perry Cup, ITF Masters World Team Championships 2026, Rome)",
+  "main": "script.js",
+  "scripts": {
+    "start": "node script.js"
+  },
+  "dependencies": {
+    "playwright": "^1.54.0"
+  }
+}

--- a/scripts/itf-masters-scraper/script.js
+++ b/scripts/itf-masters-scraper/script.js
@@ -1,0 +1,78 @@
+// Scrape the Denmark vs Germany tie (Fred Perry Cup / Men's 50, play-off for
+// 5th/6th place) from the ITF Masters World Team Championships 2026 (Rome,
+// Italy, 5-10 July 2026) on itfmasters.tournamentsoftware.com.
+//
+// Usage:
+//   npm install
+//   node script.js
+//
+// Optional env vars:
+//   PW_EXECUTABLE_PATH  - path to a Chromium binary (skips Playwright's download)
+//   HTTPS_PROXY         - proxy server to route browser traffic through
+const { chromium } = require('playwright');
+
+const START_URL =
+  'https://itfmasters.tournamentsoftware.com/find/tournament?q=World%20Team%20Championships';
+
+(async () => {
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: process.env.PW_EXECUTABLE_PATH || undefined,
+    proxy: process.env.HTTPS_PROXY ? { server: process.env.HTTPS_PROXY } : undefined,
+  });
+  const page = await (await browser.newContext()).newPage();
+
+  try {
+    // 1. Tournament search on the ITF Masters portal. The site is client-side
+    //    rendered, so wait for the network to go idle before querying the DOM.
+    await page.goto(START_URL, { waitUntil: 'networkidle', timeout: 45000 });
+
+    // 2. Open the 2026 tournament (Rome, Italy).
+    const tournament = page
+      .locator('a', { hasText: /World Team Championships/i })
+      .filter({ hasText: /2026|50/ })
+      .first();
+    await tournament.waitFor({ timeout: 20000 });
+    await tournament.click();
+    await page.waitForLoadState('networkidle');
+
+    // 3. Navigate to Draws and select the Fred Perry Cup (Men's 50) event.
+    await page.locator('a', { hasText: /^Draws$/i }).first().click();
+    await page.waitForLoadState('networkidle');
+    const event = page
+      .locator('a', { hasText: /Fred Perry Cup|Men'?s 50/i })
+      .first();
+    await event.waitFor({ timeout: 20000 });
+    await event.click();
+    await page.waitForLoadState('networkidle');
+
+    // 4. Open the 5th-8th place play-off draw if it is a separate page.
+    const playoff = page.locator('a', { hasText: /5th|play.?off/i }).first();
+    if (await playoff.count()) {
+      await playoff.click();
+      await page.waitForLoadState('networkidle');
+    }
+
+    // 5. Find the Denmark vs Germany tie and print the team score.
+    const tie = page
+      .locator('a, tr', { hasText: /Denmark/ })
+      .filter({ hasText: /Germany/ })
+      .first();
+    await tie.waitFor({ timeout: 20000 });
+    console.log('=== Denmark vs Germany (5th/6th place play-off) ===');
+    console.log((await tie.innerText()).trim());
+
+    // 6. Drill into the tie for the individual rubbers (singles + doubles).
+    if ((await tie.evaluate((el) => el.tagName)) === 'A') {
+      await tie.click();
+      await page.waitForLoadState('networkidle');
+      console.log('\n=== Individual match breakdown ===');
+      console.log(await page.locator('main, body').first().innerText());
+    }
+  } catch (err) {
+    console.error('SCRAPE FAILED:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
## Summary

Adds `scripts/itf-masters-scraper/`, a self-contained Playwright (Chromium) script that extracts the Denmark vs Germany tie result (play-off for 5th/6th place, Fred Perry Cup / Men's 50) from the ITF Masters World Team Championships 2026 (Rome, Italy, 5–10 July 2026) on `itfmasters.tournamentsoftware.com`.

The script:
- searches the ITF Masters portal for the tournament and opens it,
- waits for the client-side-rendered pages to hydrate (`networkidle` + explicit `waitFor` on locators),
- navigates Draws → Fred Perry Cup (Men's 50) → 5th–8th place play-off,
- prints the Denmark vs Germany team score and, where available, the individual singles/doubles rubbers.

## Why the script was committed instead of just executed

The remote sandbox's egress network policy returns 403 on the proxy CONNECT for `itfmasters.tournamentsoftware.com` (and general web hosts), so the browser fails with `net::ERR_TUNNEL_CONNECTION_FAILED` before any page loads; the site also serves 403 to non-browser fetchers. Run locally with `npm install && node script.js` (see the scraper README for optional `PW_EXECUTABLE_PATH` / `HTTPS_PROXY` env vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wwc8eZnRK9gVRXxGLQ21vV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wwc8eZnRK9gVRXxGLQ21vV)_